### PR TITLE
Add is_trial field to UserSubscription

### DIFF
--- a/subscription/migrations/0003_usersubscription_is_trial.py
+++ b/subscription/migrations/0003_usersubscription_is_trial.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('subscription', '0002_subscription_currency'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='usersubscription',
+            name='is_trial',
+            field=models.BooleanField(default=False, db_index=True),
+        ),
+    ]

--- a/subscription/models.py
+++ b/subscription/models.py
@@ -157,6 +157,7 @@ class UserSubscription(models.Model):
     expires = models.DateField(null=True, default=datetime.date.today)
     active = models.BooleanField(default=True)
     cancelled = models.BooleanField(default=True)
+    is_trial = models.BooleanField(default=False, db_index=True)
 
     objects = models.Manager()
     active_objects = ActiveUSManager()


### PR DESCRIPTION
## Summary
- Adds `is_trial = BooleanField(default=False, db_index=True)` to `UserSubscription`
- Adds migration `0003_usersubscription_is_trial`

## Why
Lets consumers (e.g. AstroBin) distinguish trial subscriptions from paid ones in analytics and business logic without spinning up a parallel Subscription product per trial. The field is indexed for filter performance.

## Compatibility
- New field defaults to `False`, so existing rows are unaffected
- No change to existing fields, signals, managers, or admin