### PR TITLE
Fix ActiveUSManager to override get_queryset (Django >= 1.8)

### DIFF
--- a/subscription/models.py
+++ b/subscription/models.py
@@ -147,8 +147,14 @@ auth.models.User.add_to_class('get_subscription', __user_get_subscription)
 
 class ActiveUSManager(models.Manager):
     """Custom Manager for UserSubscription that returns only live US objects."""
-    def get_query_set(self):
-        return super(ActiveUSManager, self).get_query_set().filter(active=True)
+    def get_queryset(self):
+        return super(ActiveUSManager, self).get_queryset().filter(active=True)
+
+    # Backward-compatible alias for the pre-Django-1.6 method name. Django >= 1.8
+    # only calls get_queryset(), so the old get_query_set() override was dead and
+    # active_objects silently returned ALL rows. Keep the alias delegating so any
+    # remaining direct caller still gets the active-only queryset.
+    get_query_set = get_queryset
 
 
 class UserSubscription(models.Model):


### PR DESCRIPTION
## Summary

`ActiveUSManager` only overrode `get_query_set()` — the manager method name Django removed in 1.8. On Django >= 1.8 (AstroBin runs 2.2) that override is dead code, so `UserSubscription.active_objects` silently returns **all** rows instead of only `active=True` ones.

## Changes

- Define `get_queryset()` with the `active=True` filter.
- Keep `get_query_set = get_queryset` as a delegating alias for backward compatibility.

## Notes

- Behavior change: `active_objects` now actually filters to active rows. Audited the consumer (astrobin): the 5 call sites either re-check `active`/expiry in Python or are `.update(active=False)` writers, so none rely on inactive rows being returned.
- This repo has no runnable test harness (`tests.py` is Python 2 era); the downstream astrobin pin-bump PR adds an integration test asserting `active_objects` excludes inactive rows.